### PR TITLE
Check for .ActivityView instead of .ActiveToast

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -296,7 +296,7 @@ public extension UIView {
      */
     public func makeToastActivity(position: CGPoint) {
         // sanity
-        if let _ = objc_getAssociatedObject(self, &ToastKeys.ActiveToast) as? UIView {
+        if let _ = objc_getAssociatedObject(self, &ToastKeys.ActivityView) as? UIView {
             return
         }
         


### PR DESCRIPTION
Noticed that in one of the projects I use this library that the ToastActivity won't show when there is still a Toast lingering around.